### PR TITLE
feat: Add standalone phar installer and use builtin phar

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Performs syntax-checks of your Blade templates. Just that.
 ## Features
 
 - Lint by [laravel-blade-linter](https://github.com/bdelespierre/laravel-blade-linter)
+- Downloader (laravel-blade-linter tool)
 
 ## Install
 
@@ -26,17 +27,17 @@ Performs syntax-checks of your Blade templates. Just that.
 Plug 'yaegassy/coc-blade-linter', {'do': 'yarn install --frozen-lockfile'}
 ```
 
-## Require
+## Detects: "laravel-blade-linter" tool
 
-Install `bdelespierre/laravel-blade-linter` in your "laravel" project.
+Detects the `laravel-blade-linter`. They are prioritized in order from the top.
 
-```sh
-composer require --dev bdelespierre/laravel-blade-linter
-```
+1. `bladeLinter.toolPath`
+1. `vendor/bdelespierre/laravel-blade-linter` package. (`composer require --dev bdelespierre/laravel-blade-linter`)
+1. `laravel-blade-linter` retrieved by the download feature. (`:CocCommand bladeLinter.download`)
+    - Mac/Linux: `~/.config/coc/extensions/coc-blade-linter-data/laravel-blade-linter`
+    - Windows: `~/AppData/Local/coc/extensions/coc-blade-linter-data/laravel-blade-linter`
 
-If you **do not have "laravel-blade-linter" installed**, the extension will be `disabled`.
-
-----
+## Filetype
 
 The "filetype" must be `blade` for this extension to work.
 
@@ -46,18 +47,18 @@ Set up `autocmd BufNewFile,BufRead *.blade.php set filetype=blade` in `.vimrc/in
 ## Configuration options
 
 - `bladeLinter.enable`: Enable coc-blade-linter extension, default: `true`
+- `bladeLinter.toolPath`: The path to the laravel-blade-linter phar file (Absolute path), default: `""`
 - `bladeLinter.lintOnOpen`: Lint blade file on opening, default: `true`
 - `bladeLinter.lintOnChange`: Lint blade file on change, default: `true`
 - `bladeLinter.lintOnSave`: Lint blade file on save, default: `true`
 
+## Commands
+
+- `bladeLinter.download`: Download laravel-blade-linter
+
 ## Related coc.nvim extension
 
 - [yaegassy/coc-blade-formatter](https://github.com/yaegassy/coc-blade-formatter)
-
-## WIP(Plan?)
-
-<!-- markdownlint-disable-next-line -->
-- Integrate `coc-blade-linter`, `coc-blade-formatter` and VSCode's [Laravel Snippets](hjttps://github.com/onecentlin/laravel5-snippets-vscode) into an extension called `coc-laravel-blade`?
 
 ## Thanks
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@types/node": "^14.14.22",
+    "@types/node-fetch": "^2.5.7",
     "@typescript-eslint/eslint-plugin": "^4.8.2",
     "@typescript-eslint/parser": "^4.8.2",
     "coc.nvim": "^0.0.80",
@@ -44,7 +45,9 @@
     "eslint-plugin-prettier": "^3.1.4",
     "prettier": "^2.2.0",
     "rimraf": "^3.0.2",
-    "typescript": "^4.1.2"
+    "typescript": "^4.1.2",
+    "https-proxy-agent": "^5.0.0",
+    "node-fetch": "^2.6.0"
   },
   "activationEvents": [
     "onLanguage:blade"
@@ -58,6 +61,11 @@
           "type": "boolean",
           "default": true,
           "description": "Enable coc-blade-linter extension"
+        },
+        "bladeLinter.toolPath": {
+          "type": "string",
+          "default": "",
+          "description": "The path to the laravel-blade-linter phar file (Absolute path)"
         },
         "bladeLinter.lintOnOpen": {
           "type": "boolean",
@@ -75,6 +83,12 @@
           "description": "Lint blade file on save"
         }
       }
-    }
+    },
+    "commands": [
+      {
+        "command": "bladeLinter.download",
+        "title": "Download laravel-blade-linter"
+      }
+    ]
   }
 }

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -1,0 +1,54 @@
+import { ExtensionContext, window } from 'coc.nvim';
+import { randomBytes } from 'crypto';
+import { createWriteStream, promises as fs } from 'fs';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import fetch from 'node-fetch';
+import path from 'path';
+import stream from 'stream';
+import util from 'util';
+
+const pipeline = util.promisify(stream.pipeline);
+const agent = process.env.https_proxy ? new HttpsProxyAgent(process.env.https_proxy as string) : null;
+
+export async function download(context: ExtensionContext): Promise<void> {
+  const statusItem = window.createStatusBarItem(0, { progress: true });
+  statusItem.text = `Downloading laravel-blade-linter`;
+  statusItem.show();
+
+  const downloadUrl =
+    'https://github.com/bdelespierre/laravel-blade-linter/releases/latest/download/laravel-blade-linter.phar';
+
+  // @ts-ignore
+  const resp = await fetch(downloadUrl, { agent });
+  if (!resp.ok) {
+    statusItem.hide();
+    throw new Error('Download failed');
+  }
+
+  let cur = 0;
+  const len = Number(resp.headers.get('content-length'));
+  resp.body.on('data', (chunk: Buffer) => {
+    cur += chunk.length;
+    const p = ((cur / len) * 100).toFixed(2);
+    statusItem.text = `${p}% Downloading laravel-blade-linter`;
+  });
+
+  const _path = path.join(context.storagePath, 'laravel-blade-linter');
+  const randomHex = randomBytes(5).toString('hex');
+  const tempFile = path.join(context.storagePath, `laravel-blade-linter-${randomHex}`);
+
+  const destFileStream = createWriteStream(tempFile, { mode: 0o755 });
+  await pipeline(resp.body, destFileStream);
+  await new Promise<void>((resolve) => {
+    destFileStream.on('close', resolve);
+    destFileStream.destroy();
+    setTimeout(resolve, 1000);
+  });
+
+  await fs.unlink(_path).catch((err) => {
+    if (err.code !== 'ENOENT') throw err;
+  });
+  await fs.rename(tempFile, _path);
+
+  statusItem.hide();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,63 @@
-import { ExtensionContext, window, workspace } from 'coc.nvim';
+import { commands, ExtensionContext, window, workspace } from 'coc.nvim';
 
 import fs from 'fs';
 import path from 'path';
 
 import { LintEngine } from './lint';
+import { download } from './downloader';
 
 export async function activate(context: ExtensionContext): Promise<void> {
   const extensionConfig = workspace.getConfiguration('bladeLinter');
   const isEnable = extensionConfig.get<boolean>('enable', true);
   if (!isEnable) return;
 
+  const extensionStoragePath = context.storagePath;
+  if (!fs.existsSync(extensionStoragePath)) {
+    fs.mkdirSync(extensionStoragePath);
+  }
+
   const outputChannel = window.createOutputChannel('bladeLinter');
 
-  if (!fs.existsSync(path.join('vendor', 'bdelespierre', 'laravel-blade-linter'))) {
-    outputChannel.appendLine(`${'#'.repeat(10)} bladeLinter\n`);
-    outputChannel.append('Disable the extension because "laravel-blade-linter" is not installed');
+  context.subscriptions.push(
+    commands.registerCommand('bladeLinter.download', async () => {
+      await downloadWrapper(context);
+    })
+  );
+
+  let usePhar = true;
+  // 1. bladeLinter.toolPath (phar)
+  let toolPath = extensionConfig.get('toolPath', '');
+  if (!toolPath) {
+    // 2. Project's "laravel-blade-linter" package
+    if (fs.existsSync(path.join('vendor', 'bdelespierre', 'laravel-blade-linter'))) {
+      toolPath = 'dummy';
+      usePhar = false;
+      // 3. builtin "laravel-blade-linter" phar
+    } else if (fs.existsSync(path.join(context.storagePath, 'laravel-blade-linter'))) {
+      toolPath = path.join(context.storagePath, 'laravel-blade-linter');
+    }
+  }
+
+  // Install "laravel-blade-linter" if it does not exist.
+  if (!toolPath) {
+    await downloadWrapper(context);
+    if (fs.existsSync(path.join(context.storagePath, 'laravel-blade-linter'))) {
+      toolPath = path.join(context.storagePath, 'laravel-blade-linter');
+    }
+  }
+
+  // If "laravel-blade-linter" does not exist completely, terminate the process.
+  // ----
+  // If you cancel the installation.
+  if (!toolPath) {
+    setTimeout(() => {
+      window.showErrorMessage('Exit, because "laravel-blade-linter" does not exist.');
+    }, 500);
     return;
   }
 
   const { subscriptions } = context;
-  const engine = new LintEngine(outputChannel);
+  const engine = new LintEngine(usePhar, toolPath, outputChannel);
 
   const onOpen = extensionConfig.get<boolean>('lintOnOpen');
   if (onOpen) {
@@ -58,5 +96,25 @@ export async function activate(context: ExtensionContext): Promise<void> {
       null,
       subscriptions
     );
+  }
+}
+
+async function downloadWrapper(context: ExtensionContext) {
+  let msg = 'Do you want to download "laravel-blade-linter"?';
+
+  let ret = 0;
+  ret = await window.showQuickpick(['Yes', 'Cancel'], msg);
+  if (ret === 0) {
+    try {
+      await download(context);
+    } catch (e) {
+      console.error(e);
+      msg =
+        'Download laravel-blade-linter failed, you can get it from https://github.com/bdelespierre/laravel-blade-linter';
+      window.showMessage(msg, 'error');
+      return;
+    }
+  } else {
+    return;
   }
 }

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -14,10 +14,14 @@ import cp from 'child_process';
 
 export class LintEngine {
   private collection: DiagnosticCollection;
+  private usePhar: boolean;
+  private toolPath: string;
   private outputChannel: OutputChannel;
 
-  constructor(outputChannel: OutputChannel) {
+  constructor(usePhar: boolean, toolPath: string, outputChannel: OutputChannel) {
     this.collection = languages.createDiagnosticCollection('bladeLinter');
+    this.usePhar = usePhar;
+    this.toolPath = toolPath;
     this.outputChannel = outputChannel;
   }
 
@@ -32,8 +36,13 @@ export class LintEngine {
     // Use shell
     const opts = { cwd, shell: true };
 
-    args.push('artisan');
-    args.push('blade:lint');
+    if (this.usePhar) {
+      args.push(this.toolPath);
+      args.push('lint');
+    } else {
+      args.push('artisan');
+      args.push('blade:lint');
+    }
 
     this.outputChannel.appendLine(`${'#'.repeat(10)} bladeLinter\n`);
     this.outputChannel.appendLine(`Cwd: ${opts.cwd}`);
@@ -72,7 +81,7 @@ export class LintEngine {
             msg = match[1];
             line = parseInt(match[2]);
           } else {
-            msg = 'There is a problem running blade:lint';
+            msg = 'There is a problem running larvel-blade-linter';
           }
 
           // position is "real line" - 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,6 +64,19 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
+"@types/node-fetch@^2.5.7":
+  version "2.5.10"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.10.tgz#9b4d4a0425562f9fcea70b12cb3fcdd946ca8132"
+  integrity sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
+"@types/node@*":
+  version "14.14.41"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.41.tgz#d0b939d94c1d7bd53d04824af45f1139b8c45615"
+  integrity sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==
+
 "@types/node@^14.14.22":
   version "14.14.39"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.39.tgz#9ef394d4eb52953d2890e4839393c309aa25d2d1"
@@ -149,6 +162,13 @@ acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
+
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -209,6 +229,11 @@ astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -282,6 +307,13 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -296,7 +328,7 @@ cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-debug@^4.0.1, debug@^4.1.1:
+debug@4, debug@^4.0.1, debug@^4.1.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -307,6 +339,11 @@ deep-is@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -533,6 +570,15 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
+form-data@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -623,6 +669,14 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -780,6 +834,18 @@ micromatch@^4.0.2:
     braces "^3.0.1"
     picomatch "^2.2.3"
 
+mime-db@1.47.0:
+  version "1.47.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.47.0.tgz#8cb313e59965d3c05cfbf898915a267af46a335c"
+  integrity sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==
+
+mime-types@^2.1.12:
+  version "2.1.30"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.30.tgz#6e7be8b4c479825f85ed6326695db73f9305d62d"
+  integrity sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==
+  dependencies:
+    mime-db "1.47.0"
+
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -796,6 +862,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+node-fetch@^2.6.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 once@^1.3.0:
   version "1.4.0"


### PR DESCRIPTION
## Description

laravel-blade-linter is added as a command in laravel artisan, and it required the installation of bdelespierre/laravel-blade-linter in the project.

A standalone version of the phar file is now provided in v1.5.0 and later.

**Ref**:

- https://github.com/bdelespierre/laravel-blade-linter/issues/7 
- https://github.com/bdelespierre/laravel-blade-linter/commit/47942ce3a54505b9819b978d5118435137665721 

Added the ability to download phar files in coc-blade-linter.

It is no longer mandatory to install the bdelespierre/laravel-blade-linter package in your project.

## DEMO

![coc-blade-linter-downloader](https://user-images.githubusercontent.com/188642/116017823-9bcca380-a67b-11eb-87f0-f47d71435fd3.gif)
